### PR TITLE
Timed Withdrawal Wallet Contract in Clarity.

### DIFF
--- a/turbo_contracts/Clarinet.toml
+++ b/turbo_contracts/Clarinet.toml
@@ -10,6 +10,11 @@ path = 'contracts/storage_incentives.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.timed_withdrawal_wallet]
+path = 'contracts/timed_withdrawal_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.vote_change_allowed]
 path = 'contracts/vote_change_allowed.clar'
 clarity_version = 2

--- a/turbo_contracts/contracts/timed_withdrawal_wallet.clar
+++ b/turbo_contracts/contracts/timed_withdrawal_wallet.clar
@@ -1,0 +1,116 @@
+;; Timed Withdrawal Wallet Contract
+;; A wallet that restricts withdrawals until after a specified time
+
+;; Error constants
+(define-constant ERR-NOT-AUTHORIZED (err u100))
+(define-constant ERR-WITHDRAWAL-TIME-NOT-SET (err u101))
+(define-constant ERR-WITHDRAWAL-TIME-NOT-REACHED (err u102))
+(define-constant ERR-INSUFFICIENT-BALANCE (err u103))
+(define-constant ERR-INVALID-AMOUNT (err u104))
+(define-constant ERR-INVALID-TIME (err u105))
+
+;; Contract owner
+(define-constant CONTRACT-OWNER tx-sender)
+
+;; Data variables
+(define-data-var withdrawal-time (optional uint) none)
+(define-data-var wallet-balance uint u0)
+
+;; Read-only functions
+
+;; Get the current withdrawal time
+(define-read-only (get-withdrawal-time)
+  (var-get withdrawal-time)
+)
+
+;; Get the current wallet balance
+(define-read-only (get-wallet-balance)
+  (var-get wallet-balance)
+)
+
+;; Check if withdrawal time has been reached
+(define-read-only (can-withdraw-now)
+  (match (var-get withdrawal-time)
+    time-set (>= block-height time-set)
+    false
+  )
+)
+
+;; Get current block height (for reference)
+(define-read-only (get-current-time)
+  block-height
+)
+
+;; Public functions
+
+;; Set the withdrawal time (only contract owner can call this)
+(define-public (set-withdrawal-time (timestamp uint))
+  (begin
+    ;; Check if caller is authorized
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-NOT-AUTHORIZED)
+    ;; Validate timestamp is in the future
+    (asserts! (> timestamp block-height) ERR-INVALID-TIME)
+    ;; Set the withdrawal time
+    (var-set withdrawal-time (some timestamp))
+    (ok true)
+  )
+)
+
+;; Deposit STX into the wallet
+(define-public (deposit (amount uint))
+  (begin
+    ;; Validate amount
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    ;; Transfer STX from sender to contract
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    ;; Update wallet balance
+    (var-set wallet-balance (+ (var-get wallet-balance) amount))
+    (ok amount)
+  )
+)
+
+;; Withdraw STX from the wallet (only after withdrawal time)
+(define-public (withdraw (amount uint))
+  (let (
+    (current-balance (var-get wallet-balance))
+    (withdrawal-timestamp (var-get withdrawal-time))
+  )
+    (begin
+      ;; Check if caller is authorized
+      (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-NOT-AUTHORIZED)
+      ;; Validate amount
+      (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+      ;; Check if withdrawal time is set
+      (asserts! (is-some withdrawal-timestamp) ERR-WITHDRAWAL-TIME-NOT-SET)
+      ;; Check if withdrawal time has been reached
+      (asserts! (>= block-height (unwrap-panic withdrawal-timestamp)) ERR-WITHDRAWAL-TIME-NOT-REACHED)
+      ;; Check if sufficient balance
+      (asserts! (>= current-balance amount) ERR-INSUFFICIENT-BALANCE)
+      ;; Update wallet balance
+      (var-set wallet-balance (- current-balance amount))
+      ;; Transfer STX from contract to sender
+      (try! (as-contract (stx-transfer? amount tx-sender CONTRACT-OWNER)))
+      (ok amount)
+    )
+  )
+)
+
+;; Withdraw all available funds
+(define-public (withdraw-all)
+  (let (
+    (current-balance (var-get wallet-balance))
+  )
+    (withdraw current-balance)
+  )
+)
+
+;; Emergency function to reset withdrawal time (only owner)
+(define-public (reset-withdrawal-time)
+  (begin
+    ;; Check if caller is authorized
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-NOT-AUTHORIZED)
+    ;; Reset withdrawal time
+    (var-set withdrawal-time none)
+    (ok true)
+  )
+)

--- a/turbo_contracts/tests/timed_withdrawal_wallet.test.ts
+++ b/turbo_contracts/tests/timed_withdrawal_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body>
<hr>
<h1>Timed Withdrawal Wallet Contract ⏳💰</h1>
<p>A Clarity smart contract for Stacks that creates a <strong>time-locked wallet</strong>, allowing deposits at any time but restricting withdrawals until a specified block height (time).</p>
<hr>
<h2>📌 Features</h2>
<ul>
<li>
<p><strong>Time-Locked Withdrawals</strong> – Only the contract owner can withdraw funds after the specified withdrawal time.</p>
</li>
<li>
<p><strong>Secure Deposits</strong> – Anyone can deposit STX into the wallet.</p>
</li>
<li>
<p><strong>Owner-Only Controls</strong> – Only the contract owner can set/reset withdrawal times and withdraw funds.</p>
</li>
<li>
<p><strong>Error Handling</strong> – Provides clear error codes for invalid operations.</p>
</li>
<li>
<p><strong>Emergency Reset</strong> – The owner can reset the withdrawal time if needed.</p>
</li>
</ul>
<hr>
<h2>⚙️ Contract Overview</h2>
<h3>Constants</h3>
<ul>
<li>
<p><code inline="">CONTRACT-OWNER</code> – The wallet owner (set as <code inline="">tx-sender</code> at deployment).</p>
</li>
<li>
<p>Error codes:</p>
<ul>
<li>
<p><code inline="">ERR-NOT-AUTHORIZED (u100)</code> – Caller is not the owner.</p>
</li>
<li>
<p><code inline="">ERR-WITHDRAWAL-TIME-NOT-SET (u101)</code> – Withdrawal time not defined.</p>
</li>
<li>
<p><code inline="">ERR-WITHDRAWAL-TIME-NOT-REACHED (u102)</code> – Withdrawal attempted before allowed time.</p>
</li>
<li>
<p><code inline="">ERR-INSUFFICIENT-BALANCE (u103)</code> – Not enough funds to withdraw.</p>
</li>
<li>
<p><code inline="">ERR-INVALID-AMOUNT (u104)</code> – Deposit/withdrawal amount must be greater than zero.</p>
</li>
<li>
<p><code inline="">ERR-INVALID-TIME (u105)</code> – Withdrawal time must be in the future.</p>
</li>
</ul>
</li>
</ul>
<hr>
<h3>Data Variables</h3>
<ul>
<li>
<p><code inline="">withdrawal-time (optional uint)</code> – The block height after which withdrawals are allowed.</p>
</li>
<li>
<p><code inline="">wallet-balance (uint)</code> – The current STX balance held in the wallet.</p>
</li>
</ul>
<hr>
<h3>Read-Only Functions</h3>

Function | Description
-- | --
get-withdrawal-time | Returns the set withdrawal block height (if any).
get-wallet-balance | Returns the current wallet balance.
can-withdraw-now | Returns true if the withdrawal time has been reached.
get-current-time | Returns the current block height.


<hr>
<h2>🔐 Security Considerations</h2>
<ul>
<li>
<p>Only the <strong>contract owner</strong> can withdraw funds or modify withdrawal settings.</p>
</li>
<li>
<p>Deposits can be made by <strong>any account</strong>.</p>
</li>
<li>
<p>All functions validate inputs to prevent incorrect usage (e.g., invalid times, zero amounts).</p>
</li>
<li>
<p>Funds remain locked until the set block height is reached.</p>
</li>
</ul>
<hr>
<h2>🚀 Example Workflow</h2>
<ol>
<li>
<p><strong>Deploy contract</strong> – Owner becomes the deployer (<code inline="">tx-sender</code>).</p>
</li>
<li>
<p><strong>Set withdrawal time</strong> – Owner calls <code inline="">set-withdrawal-time &lt;future-block&gt;</code>.</p>
</li>
<li>
<p><strong>Deposit funds</strong> – Any user can deposit using <code inline="">deposit</code>.</p>
</li>
<li>
<p><strong>Wait until block height</strong> – Withdrawal blocked until <code inline="">block-height &gt;= withdrawal-time</code>.</p>
</li>
<li>
<p><strong>Withdraw funds</strong> – Owner can call <code inline="">withdraw &lt;amount&gt;</code> or <code inline="">withdraw-all</code>.</p>
</li>
</ol>
<hr>
<h2>📜 License</h2>
<p>This contract is open-source and free to use under the MIT License.</p>
<hr>
</body></html><!--EndFragment-->
</body>
</html>